### PR TITLE
Editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,6 +27,7 @@
         "react-highlight.js": "^1.0.7",
         "react-router-dom": "^6.19.0",
         "react-scripts": "5.0.1",
+        "react-simple-code-editor": "^0.13.1",
         "socket.io-client": "^4.7.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -15280,6 +15281,15 @@
         }
       }
     },
+    "node_modules/react-simple-code-editor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz",
+      "integrity": "sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -29115,6 +29125,12 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-simple-code-editor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz",
+      "integrity": "sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "react-highlight.js": "^1.0.7",
     "react-router-dom": "^6.19.0",
     "react-scripts": "5.0.1",
+    "react-simple-code-editor": "^0.13.1",
     "socket.io-client": "^4.7.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/client/src/components/pages/CodeBlock/CodeBlock.css
+++ b/client/src/components/pages/CodeBlock/CodeBlock.css
@@ -1,0 +1,3 @@
+.textAreaStyles {
+  outline-color: transparent;
+}

--- a/client/src/components/pages/CodeBlock/CodeBlockPage.tsx
+++ b/client/src/components/pages/CodeBlock/CodeBlockPage.tsx
@@ -1,12 +1,14 @@
 import { useParams } from "react-router";
 import axios from "axios";
-import { ChangeEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import CodeBlockModel from "../../models/CodeBlock";
-import { TextField } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import { socket } from "../../layout/Main";
-import "highlight.js/styles/github.css";
-import Highlight from "react-highlight.js";
+import Editor from "react-simple-code-editor";
+import { highlight, languages } from "prismjs";
+import "prismjs/components/prism-clike";
+import "prismjs/components/prism-javascript";
+import "prismjs/themes/prism.css";
 
 function CodeBlockPage(): JSX.Element {
   const params = useParams();
@@ -37,8 +39,8 @@ function CodeBlockPage(): JSX.Element {
   }, [codeBlockId, codeBlockObj]);
 
   //Sending codeChange event to the server
-  const codeChange = (e: ChangeEvent<HTMLInputElement>) => {
-    socket.emit("code change", e.target.value, codeBlockId);
+  const codeChange = (val: string) => {
+    socket.emit("code change", val, codeBlockId);
   };
 
   //Receiving code changes back from the server : data + id (eventName, listener)
@@ -70,17 +72,19 @@ function CodeBlockPage(): JSX.Element {
           >
             {codeBlockObj.title}
           </Typography>
-          <Highlight language="javascript">{codeBlockObj.code}</Highlight>
-          <TextField
-            fullWidth
-            id="outlined-multiline-static"
-            multiline
-            label={"code"}
+          <Editor
             value={codeBlockObj.code}
-            onChange={codeChange}
-            InputProps={{
-              readOnly: codeBlockObj.entrances === null,
+            onValueChange={(value) => codeChange(value)}
+            highlight={(code) =>
+              highlight(code, languages.javascript, "javascript")
+            }
+            padding={10}
+            style={{
+              fontFamily: '"Fira code", "Fira Mono", monospace',
+              fontSize: 20,
+              marginBlockStart: 50,
             }}
+            readOnly={codeBlockObj.entrances === null}
           />
         </div>
       ) : (

--- a/client/src/components/pages/CodeBlock/CodeBlockPage.tsx
+++ b/client/src/components/pages/CodeBlock/CodeBlockPage.tsx
@@ -6,8 +6,6 @@ import Typography from "@mui/material/Typography";
 import { socket } from "../../layout/Main";
 import Editor from "react-simple-code-editor";
 import { highlight, languages } from "prismjs";
-import "prismjs/components/prism-clike";
-import "prismjs/components/prism-javascript";
 import "prismjs/themes/prism.css";
 
 function CodeBlockPage(): JSX.Element {

--- a/client/src/components/pages/CodeBlock/CodeBlockPage.tsx
+++ b/client/src/components/pages/CodeBlock/CodeBlockPage.tsx
@@ -7,6 +7,7 @@ import { socket } from "../../layout/Main";
 import Editor from "react-simple-code-editor";
 import { highlight, languages } from "prismjs";
 import "prismjs/themes/prism.css";
+import "./CodeBlock.css";
 
 function CodeBlockPage(): JSX.Element {
   const params = useParams();
@@ -33,8 +34,8 @@ function CodeBlockPage(): JSX.Element {
   };
 
   useEffect(() => {
-    if (!codeBlockObj) getCodeBlock(codeBlockId);
-  }, [codeBlockId, codeBlockObj]);
+    getCodeBlock(codeBlockId);
+  }, [codeBlockId]);
 
   //Sending codeChange event to the server
   const codeChange = (val: string) => {
@@ -82,6 +83,7 @@ function CodeBlockPage(): JSX.Element {
               fontSize: 20,
               marginBlockStart: 50,
             }}
+            textareaClassName="textAreaStyles"
             readOnly={codeBlockObj.entrances === null}
           />
         </div>


### PR DESCRIPTION
-installed react-simple-code-editor
-replaced the highlight and textfield with the react-simple-code-editor
-changed the useEffect to call the function that's fetching the code block info to be only when the component has first created and inserted to the dom/when the code block id changed
-added css file for the textarea border to be transparent